### PR TITLE
change goto implementation to work for firefox

### DIFF
--- a/HentaiVerse/hvAutoAttack/hvAutoAttack.user.js
+++ b/HentaiVerse/hvAutoAttack/hvAutoAttack.user.js
@@ -236,7 +236,7 @@ function delValue (item) { // 删除数据
 }
 
 function goto () { // 前进
-  window.location.href = window.location.search
+  window.location.href = window.location
   setTimeout(goto, 5000)
 }
 


### PR DESCRIPTION
This might be a solution for [issue-56](https://github.com/dodying/UserJs/issues/56)

I was using the scirpt with firefox. The page will idle before encounter the riddle master.
Even if I set the option "reload when page stays idle", the page still never reloads.

Changing the implementation of function "goto" will fix the reload function and therefor reload the page. Then, the alarm of riddle master works again.

Not sure whether this change works in other browsers.
